### PR TITLE
Fixed crash app if a meeting doesn't exist

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { DeskproAppProvider } from "@deskpro/app-sdk";
 import { queryClient } from "./query";
 import App from "./App";
+
 import "flatpickr/dist/themes/light.css";
 import "tippy.js/dist/tippy.css";
 import "simplebar/dist/simplebar.min.css";

--- a/src/pages/HomePage/hooks.ts
+++ b/src/pages/HomePage/hooks.ts
@@ -40,7 +40,7 @@ const useMeetings: UseMeetings = () => {
     queryKey: [QueryKey.MEETINGS, id],
     queryFn: (client: IDeskproClient) => getMeetingService(client, id),
     enabled: size(recurrenceMeetingIds) > 0,
-
+    useErrorBoundary: false,
   })));
 
   return {


### PR DESCRIPTION
Story https://app.shortcut.com/deskpro/story/154900/zoom-fail-during-creating-recurring-meeting