### PR TITLE
[feature] SC-166737/improve app proxy security by restricting where token replacements can go

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -46,10 +46,10 @@
         "timeout": 20,
         "settingsInjection": {
           "client_id": {
-            "headers": ["Authorization"]
+            "header": ["Authorization"]
           },
           "client_secret": {
-            "headers": ["Authorization"]
+            "header": ["Authorization"]
           }
         }
       }

--- a/manifest.json
+++ b/manifest.json
@@ -40,7 +40,19 @@
         "methods": ["GET", "POST", "DELETE"],
         "timeout": 20
       },
-      { "url": "https://zoom.us/oauth/.*", "methods": ["POST"], "timeout": 20 }
+      {
+        "url": "https://zoom.us/oauth/.*",
+        "methods": ["POST"],
+        "timeout": 20,
+        "settingsInjection": {
+          "client_id": {
+            "headers": ["Authorization"]
+          },
+          "client_secret": {
+            "headers": ["Authorization"]
+          }
+        }
+      }
     ]
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,11 +14,6 @@ export const ACCESS_TOKEN = `[user[${ACCESS_TOKEN_PATH}]]`;
 export const REFRESH_TOKEN_PATH = "oauth/global/refresh_token";
 export const REFRESH_TOKEN = `[user[${REFRESH_TOKEN_PATH}]]`;
 
-export const placeholders = {
-  client_id: "__client_id__",
-  client_secret: "__client_secret__",
-};
-
 /** Zoom */
 export const REST_URL = "https://api.zoom.us/v2";
 


### PR DESCRIPTION
This pull request introduces improvements to how sensitive Zoom OAuth credentials are handled and simplifies the codebase by removing unused constants. The main focus is on securely injecting `client_id` and `client_secret` into request headers for OAuth calls, and cleaning up unused placeholder variables.

**Zoom OAuth credential handling:**

* Updated the Zoom OAuth endpoint configuration in `manifest.json` to inject `client_id` and `client_secret` into the `Authorization` headers for POST requests, improving security and flexibility.

**Codebase cleanup:**

* Removed unused `placeholders` for `client_id` and `client_secret` from `src/constants.ts`, reducing clutter and potential confusion.

## Summary by Sourcery

Securely inject Zoom OAuth credentials into request headers for POST calls and clean up unused placeholder constants

New Features:
- Securely inject Zoom OAuth client_id and client_secret into Authorization headers for POST requests

Chores:
- Remove unused client_id and client_secret placeholder constants from src/constants.ts